### PR TITLE
chore(deps): bump tods-competition-factory to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     "jwt-decode": "^4.0.0",
     "navigo": "^8.11.1",
     "svelte": "^5.53.6",
-    "tods-competition-factory": "4.2.0"
+    "tods-competition-factory": "5.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Bumps `tods-competition-factory` from `4.2.0` → `5.0.0` (published 2026-05-31)
- See factory's [4.x → 5.0.0 migration guide](https://github.com/CourtHive/competition-factory/blob/master/documentation/docs/migration/4.x-to-5.0.0.md)

## Local verification

- `pnpm lint` — clean
- `pnpm check-types` — clean
- `pnpm test --run` — 278 tests pass across 18 files

## Test plan

- [ ] CI strip-link path resolves `5.0.0` from npm
- [ ] Run `pnpm test:e2e` against a fresh dev server
- [ ] Smoke INTENNSE scoring journey end-to-end