### PR TITLE
chore(deps): bump tods-competition-factory to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     "jwt-decode": "^4.0.0",
     "navigo": "^8.11.1",
     "svelte": "^5.53.6",
-    "tods-competition-factory": "6.0.0"
+    "tods-competition-factory": "6.0.2"
   }
 }


### PR DESCRIPTION
Bump tods-competition-factory to 6.0.2 (latest — bug fixes).