### PR TITLE
chore(deps): bump courthive-components to 3.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "@courthive/scoring-visualizations": "^0.2.2",
     "axios": "^1.6.5",
-    "courthive-components": "3.4.6",
+    "courthive-components": "3.5.1",
     "d3": "^7.9.0",
     "jwt-decode": "^4.0.0",
     "navigo": "^8.11.1",


### PR DESCRIPTION
Bumps `courthive-components` 3.4.6 → 3.5.1 (already published; this repo was two minors behind). Real version in package.json + `link:` retained in the pnpm-workspace override for local dev, per the canonical pattern. `check-types` passes against 3.5.1's API locally (the repo links the local 3.5.1 checkout).